### PR TITLE
fix: preserve todo order when loading

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -98,7 +98,7 @@ async function addTodo() {
   const text = elements.todoInput.value.trim();
   if (text) {
     const newTodo = await window.electronAPI.addTodo({ text });
-    addTodoToUI(newTodo);
+    addTodoToUI(newTodo, true);
     elements.todoInput.value = '';
     updateStats();
     
@@ -115,7 +115,7 @@ async function loadTodos() {
   if (todos.length === 0) {
     showEmptyState();
   } else {
-    todos.forEach(todo => addTodoToUI(todo));
+    todos.forEach(todo => addTodoToUI(todo, false));
   }
   
   updateStats();
@@ -148,14 +148,18 @@ async function clearCompleted() {
 }
 
 // UI操作
-function addTodoToUI(todo) {
+function addTodoToUI(todo, atTop = true) {
   const emptyState = elements.todoList.querySelector('.empty-state');
   if (emptyState) {
     emptyState.remove();
   }
 
   const todoItem = createTodoItemElement(todo);
-  elements.todoList.prepend(todoItem);
+  if (atTop) {
+    elements.todoList.prepend(todoItem);
+  } else {
+    elements.todoList.appendChild(todoItem);
+  }
   // 事件由委托处理，无需逐项绑定
 }
 


### PR DESCRIPTION
## Summary
- keep existing todos in creation order on load
- support adding todos at either end of the list

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a1281b760832b925b65deb5ac2b58